### PR TITLE
added prom and metrics api

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -5,11 +5,12 @@ This template uses the basic Next.js [`create-next-app`](https://github.com/verc
 
 ### Technologies Implemented
 
-This project uses 
-* [Next.js](https://nextjs.org/)
-* [Tailwind CSS](https://tailwindcss.com/)
-* [Jest](https://jestjs.io/) for unit testing
-* [Cypress](https://www.cypress.io/) for end-to-end testing.
+This project uses
+
+- [Next.js](https://nextjs.org/)
+- [Tailwind CSS](https://tailwindcss.com/)
+- [Jest](https://jestjs.io/) for unit testing
+- [Cypress](https://www.cypress.io/) for end-to-end testing.
 
 ## How to Implement/Get Started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "11.1.2",
+        "prom-client": "^12.0.0",
         "react": "17.0.2",
         "react-dom": "17.0.2"
       },
@@ -2984,6 +2985,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "node_modules/blob-util": {
       "version": "2.0.2",
@@ -10552,6 +10558,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
@@ -12137,6 +12155,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dependencies": {
+        "bintrees": "1.0.1"
       }
     },
     "node_modules/terminal-link": {
@@ -15200,6 +15226,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "blob-util": {
       "version": "2.0.2",
@@ -20953,6 +20984,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prompts": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
@@ -22189,6 +22228,14 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "terminal-link": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "next": "11.1.2",
+    "prom-client": "^12.0.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },

--- a/pages/api/metrics.js
+++ b/pages/api/metrics.js
@@ -1,0 +1,8 @@
+import { register, collectDefaultMetrics } from 'prom-client'
+
+collectDefaultMetrics({ prefix: 'omnidevfrontend_' })
+
+export default function handler(req, res) {
+  res.setHeader('Content-type', register.contentType)
+  res.send(register.metrics())
+}


### PR DESCRIPTION
### Description

Exposed prom metrics via /api/metrics

### What to test for/How to test
Can test by viewing metrics on localhost:3000/api/metrics

### Addtional Notes
Version 12.0.0 of prom-client is being used since an empty object is returned if not. This should be investigated when a new release of prom-client is available.

/api/metrics should be locked down before going to prod. digital-centre will hopefully come up with a solution