### PR TITLE
Add security headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,39 @@
+const securityHeaders = [
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'on',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()',
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-XSS-Protection',
+    value: '1; mode=block',
+  },
+  {
+    key: 'Content-Security-Policy',
+    value:
+      "default-src 'self'; script-src-elem 'self'; script-src 'unsafe-eval'; connect-src 'self'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com",
+  },
+]
+
 module.exports = {
   reactStrictMode: true,
   //
@@ -7,5 +43,13 @@ module.exports = {
     locales: ['en', 'fr'],
     defaultLocale: 'en',
     localDetection: true,
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ]
   },
 }


### PR DESCRIPTION
## [DTSCI-85 - Next Template - Add security headers to pages](https://jira-dev.bdm-dev.dts-stn.com/browse/DC-XXX) (Jira Issue)

### Description

The purpose of this PR is to add security headers across every page in the project. NextJS supports adding these headers in it's config as can be seen [here](https://nextjs.org/docs/advanced-features/security-headers). I've added most of the basic headers as suggested by NextJS' documentation and other sources but also added a custom CSP (Content Security Policy). 

One thing that you'll notice within the CSP is that I've given `style-src` a value of `unsafe-inline`. This is mandatory in order for literally all of our styling to be visible and is okay in this context because we are using this for styling, not scripting. Setting it to `self` instead, for example, would result in a lot of console errors and a page with broken styling. Since the rest of our CSP directives are strong, there isn't very much that a CSS-based XSS attack could achieve.

Since all of our pages are statically served, this eliminates the possibility of us using a nonce instead.

Twitter and Spotify are two examples of websites using `unsafe-inline` and both have very good security scores (perfect in Twitter's case) going off of these tests:
- [Spotify](https://observatory.mozilla.org/analyze/spotify.com)
- [Twitter](https://observatory.mozilla.org/analyze/twitter.com)

### What to test for/How to test

1. Pull in branch
2. Type `npm run dev`
3. Open dev tools/inspect page
4. Go to network tab
5. Select `localhost`
6. Click the `Headers` tab
7. Look under the response headers tab and confirm the headers that were set in our Next config are present
