### PR TITLE
Couple security changes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,12 +25,12 @@ const securityHeaders = [
   },
   {
     key: 'X-XSS-Protection',
-    value: '1; mode=block',
+    value: '0',
   },
   {
     key: 'Content-Security-Policy',
     value:
-      "default-src 'self'; script-src-elem 'self'; script-src 'unsafe-eval'; connect-src 'self'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com",
+      "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'; object-src 'none'; script-src-elem 'self'; script-src 'unsafe-eval'; connect-src 'self'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com",
   },
 ]
 


### PR DESCRIPTION
## [DTSCI-85 - Next Template - Add security headers to pages](https://jira-dev.bdm-dev.dts-stn.com/browse/DC-XXX) (Jira Issue)

### Description

@shewood pointed out that the X-XSS protection header has been deprecated by modern browsers. By explicitly setting it's value to `0`, we disable the XSS Auditor, and not allow it to take the default behavior of the browser handling the response. In addition to that, I've also added a few directives to our content security policy as recommended by [https://observatory.mozilla.org/](https://observatory.mozilla.org/) to maximize our project's security.

### What to test for/How to test

1. Pull in branch
2. Type `npm run dev`
3. Open dev tools/inspect page
4. Go to network tab
5. Select `localhost`
6. Click the `Headers` tab
7. Look under the response headers tab and confirm the headers that were set in our Next config are present
