### PR TITLE
Add img-src definition to CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -39,7 +39,7 @@ const securityHeaders = [
   {
     key: 'Content-Security-Policy',
     value:
-      "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'; object-src 'none'; script-src-elem 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com",
+      "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'; object-src 'none'; script-src-elem 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:",
   },
 ]
 


### PR DESCRIPTION
### Description

Small PR to fix a bug with the CSP. There have been a couple teams reach out with issues relating to the CSP when using `next/image`.  This fix has already been implemented on the Virtual Assistant and Digital Center projects and is working.