### PR TITLE
have zap only run on push to main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,8 +7,6 @@ name: Security - ZAP
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 # We have many jobs
 jobs:


### PR DESCRIPTION
## [DTSCI-XXX](https://jira-dev.bdm-dev.dts-stn.com/browse/DTSCI-XXX) (Jira Issue)

### Description
Right now, ZAP runs on every PR and then again when the PR is merged to Main. 
It takes a long time for ZAP to run with every PR. 

List of proposed changes:
Have ZAP run only when the PR is approved and the code is being merged with Main. 

-
-

### What to test for/How to test

### Additional Notes
